### PR TITLE
Multiples of 3 and 5

### DIFF
--- a/euler/problem1.py
+++ b/euler/problem1.py
@@ -1,0 +1,14 @@
+class Problem1(object):
+    def multiples(self):
+        answer = 0
+
+        for x in range(0, self.upper_limit):
+            if x % 3 is 0:
+                answer += x
+            elif x % 5 is 0:
+                answer += x
+
+        return answer
+
+    def __init__(self, limit):
+        self.upper_limit = limit

--- a/tests/test_problem1.py
+++ b/tests/test_problem1.py
@@ -1,0 +1,7 @@
+import unittest
+from euler.problem1 import Problem1
+
+
+class TestEngine(unittest.TestCase):
+    def test_shouldReturnSolution(self):
+        self.assertEqual(233168, Problem1(1000).multiples())


### PR DESCRIPTION
### Problem
Find all the multiples of 3 and 5 below the upper bound of 1000.

### Solution
`233168`

### Description
This involved using modulo math to test for the absence of a remainder.  Those values that divide evenly are added together to form the solution

### Technical notes
This could be expanded to allow for a list of integers to be used instead of hard coded values.